### PR TITLE
Fix leading slash for image paths

### DIFF
--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -80,7 +80,7 @@ params:
     url: /
     button: true
   sidebar:
-    # Logo (from /images/logos/___.svg)
+    # Logo (from static/images/logos/___.svg)
     logo: fresh-square
     sections:
     - title: User
@@ -138,7 +138,7 @@ params:
     features:
     - title: Powerful and unified interface
       text: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin ornare magna eros, eu pellentesque tortor vestibulum ut. Maecenas non massa sem. Etiam finibus odio quis feugiat facilisis.
-      # Icon (from /images/illustrations/icons/___.svg)
+      # Icon (from static/images/illustrations/icons/___.svg)
       icon: laptop-globe
     - title: Cross-device synchronisation
       text: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin ornare magna eros, eu pellentesque tortor vestibulum ut. Maecenas non massa sem. Etiam finibus odio quis feugiat facilisis.
@@ -175,7 +175,7 @@ params:
     # action: https://formspree.io/f/<form_id>
     # method: POST
   footer:
-    # Logo (from /images/logos/___)
+    # Logo (from static/images/logos/___)
     logo: fresh-white-alt.svg
     # Social Media Title
     socialmediatitle: Follow Us

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -9,7 +9,7 @@
     <div class="columns">
       <div class="column">
         <div class="footer-logo">
-          <img src="{{ printf "/images/logos/%s" $logo | relURL }}">
+          <img src="{{ printf "images/logos/%s" $logo | relURL }}">
         </div>
       </div>
       {{- range $quickLinks }}
@@ -46,7 +46,7 @@
 
             {{- if $bulmaLogo }}
             <a href="https://bulma.io" target="_blank">
-              <img src="{{ "/images/logos/made-with-bulma.png" | relURL }}" alt="Made with Bulma" width="128" height="24">
+              <img src="{{ "images/logos/made-with-bulma.png" | relURL }}" alt="Made with Bulma" width="128" height="24">
             </a>
             {{- end }}
           </div>

--- a/layouts/partials/hero-body.html
+++ b/layouts/partials/hero-body.html
@@ -24,7 +24,7 @@
       </div>
       <div class="column is-5 is-offset-1">
         <figure class="image is-4by3">
-          <img src="{{ printf "/images/%s" $image | relURL }}" alt="Description">
+          <img src="{{ printf "images/%s" $image | relURL }}" alt="Description">
         </figure>
       </div>
     </div>

--- a/layouts/partials/hero-footer.html
+++ b/layouts/partials/hero-footer.html
@@ -7,7 +7,7 @@
         {{- range $clientLogos }}
         <li>
           <a {{ if .url }} href="{{ .url }}" {{ end }}>
-            <img class="partner-logo" src="{{ printf "/images/logos/clients/%s.svg" .logo | relURL }}">
+            <img class="partner-logo" src="{{ printf "images/logos/clients/%s.svg" .logo | relURL }}">
           </a>
         </li>
         {{- end }}

--- a/layouts/partials/navbar-clone.html
+++ b/layouts/partials/navbar-clone.html
@@ -8,7 +8,7 @@
     <div class="navbar-brand">
       {{- if $navbarLogo}}
       <a class="navbar-item" href="{{ $navbarLogo.link }}">
-        <img src="{{ printf "/images/%s" $navbarLogo.image | relURL }}" alt="" width="{{ $navbarLogoWidth }}" height="{{ $navbarLogoHeight }}">
+        <img src="{{ printf "images/%s" $navbarLogo.image | relURL }}" alt="" width="{{ $navbarLogoWidth }}" height="{{ $navbarLogoHeight }}">
       </a>
       {{- end}}
 

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -8,7 +8,7 @@
     <div class="navbar-brand">
       {{- if $navbarLogo}}
       <a class="navbar-item" href="{{ $navbarLogo.link }}">
-        <img src="{{ printf "/images/%s" $navbarLogo.image | relURL }}" alt="" width="{{ $navbarLogoWidth }}" height="{{ $navbarLogoHeight }}">
+        <img src="{{ printf "images/%s" $navbarLogo.image | relURL }}" alt="" width="{{ $navbarLogoWidth }}" height="{{ $navbarLogoHeight }}">
       </a>
       {{- end}}
 

--- a/layouts/partials/section1.html
+++ b/layouts/partials/section1.html
@@ -19,7 +19,7 @@
               <h4>{{ .title }}</h4>
             </div>
             <div class="card-icon">
-                <img src="{{ printf "/images/illustrations/icons/%s.svg" .icon | relURL }}">
+                <img src="{{ printf "images/illustrations/icons/%s.svg" .icon | relURL }}">
             </div>
             <div class="card-text">
                 <p>{{ .text }}</p>

--- a/layouts/partials/section2.html
+++ b/layouts/partials/section2.html
@@ -15,7 +15,7 @@
         <article class="media icon-box">
           <figure class="media-left">
             <p class="image">
-              <img src="{{ printf "/images/illustrations/icons/%s.svg" .icon | relURL }}">
+              <img src="{{ printf "images/illustrations/icons/%s.svg" .icon | relURL }}">
             </p>
           </figure>
           <div class="media-content mt-50">

--- a/layouts/partials/section3.html
+++ b/layouts/partials/section3.html
@@ -9,7 +9,7 @@
     <div class="columns">
       <div class="column is-10 is-offset-1">
         <div class="has-text-centered">
-          <img class="pushed-image" src="{{ printf "/images/%s" $image | relURL }}">
+          <img class="pushed-image" src="{{ printf "images/%s" $image | relURL }}">
         </div>
       </div>
     </div>

--- a/layouts/partials/section4.html
+++ b/layouts/partials/section4.html
@@ -21,7 +21,7 @@
               {{ .quote }}
             </blockquote>
             <div class="author">
-              <img src="{{ printf "/images/illustrations/faces/%s.png" (string .img) | relURL }}" alt=""/>
+              <img src="{{ printf "images/illustrations/faces/%s.png" (string .img) | relURL }}" alt=""/>
               <h5>{{ .name }}</h5>
               <span>{{ .job }}</span>
             </div>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -3,7 +3,7 @@
 {{- $sections := index $sidebar "sections" }}
 <div class="sidebar">
   <div class="sidebar-header">
-    <img src="{{ printf "/images/logos/%s.svg" $logo | relURL }}">
+    <img src="{{ printf "images/logos/%s.svg" $logo | relURL }}">
     <a class="sidebar-close" href="javascript:void(0);">
       <i data-feather="x"></i>
     </a>

--- a/layouts/partials/single/sidebar.html
+++ b/layouts/partials/single/sidebar.html
@@ -1,7 +1,7 @@
 {{- $logo     := .Params.sidebarlogo }}
 <div class="sidebar">
   <div class="sidebar-header">
-    <img src="{{ printf "/images/logos/%s.svg" $logo | relURL }}">
+    <img src="{{ printf "images/logos/%s.svg" $logo | relURL }}">
     <a class="sidebar-close" href="javascript:void(0);">
       <i data-feather="x"></i>
     </a>


### PR DESCRIPTION
Removed leading / on image paths to support site theme deployed to sub pages e.g. `https://unstableunicorn.gitlab.io/hugo-fresh`
Updated example hugo.yaml comments to be clearer with changes to path handling.